### PR TITLE
[GFX-724] fix(runtime): PathHelper.Combine 绝对路径段正确追加分隔符

### DIFF
--- a/Runtime/Helper/PathHelper.cs
+++ b/Runtime/Helper/PathHelper.cs
@@ -115,11 +115,6 @@ namespace GameFrameX.Runtime
                     continue;
                 }
 
-                if (path.StartsWithFast(separatorA) || path.StartsWithFast(separatorB))
-                {
-                    continue;
-                }
-
                 sb.Append(separatorA);
             }
 

--- a/Tests/UtilityPathTests.cs
+++ b/Tests/UtilityPathTests.cs
@@ -225,5 +225,58 @@ namespace GameFrameX.Tests
         }
 
         #endregion
+
+        #region PathHelper.Combine
+
+        [Test]
+        public void Combine_SingleSegment_ReturnsUnchanged()
+        {
+            string result = PathHelper.Combine("img.png");
+            Assert.AreEqual("img.png", result);
+        }
+
+        [Test]
+        public void Combine_TwoRelativeSegments_AddsSeparator()
+        {
+            string result = PathHelper.Combine("cache", "img.png");
+            Assert.AreEqual("cache/img.png", result);
+        }
+
+        [Test]
+        public void Combine_AbsolutePathSegment_AppendsSeparator()
+        {
+            string result = PathHelper.Combine("/Users/blank/cache", "img.png");
+            Assert.AreEqual("/Users/blank/cache/img.png", result);
+        }
+
+        [Test]
+        public void Combine_TrailingSlashSegment_DoesNotDuplicate()
+        {
+            string result = PathHelper.Combine("cache/", "img.png");
+            Assert.AreEqual("cache/img.png", result);
+        }
+
+        [Test]
+        public void Combine_PureSeparatorSegment_DoesNotDuplicate()
+        {
+            string result = PathHelper.Combine("/", "img.png");
+            Assert.AreEqual("/img.png", result);
+        }
+
+        [Test]
+        public void Combine_TrailingBackslashSegment_DoesNotDuplicate()
+        {
+            string result = PathHelper.Combine("dir\\", "file.txt");
+            Assert.AreEqual("dir\\file.txt", result);
+        }
+
+        [Test]
+        public void Combine_MultipleSegments_AbsolutePathJoint()
+        {
+            string result = PathHelper.Combine("/Users", "blank", "cache", "img.png");
+            Assert.AreEqual("/Users/blank/cache/img.png", result);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary

- 删除 `Runtime/Helper/PathHelper.cs` 中 `Combine` 非末段拼接的 `StartsWithFast(separator)` 跳过分支：以 `/` 开头且不以分隔符结尾的绝对路径段不再与后段粘连（`/Users/blank/cache` + `img.png` 旧产出 `/Users/blank/cacheimg.png`）
- 纯 `/` 段、尾 `/`、尾 `\` 段行为不变（仍由 `EndsWith` 判定覆盖）；对外 API 签名不变
- `Tests/UtilityPathTests.cs` 新增 `#region PathHelper.Combine` 七个回归用例（对照 GameFrameX.Godot 2513f60 用例语义）

## Test plan

- [x] 独立差分验证（dotnet 10 + 真实源码 + UnityEngine shim）：修复前 7 用例 2 败（两个绝对路径用例，复现 issue 现象）→ 修复后 7/7 通过；其余 5 类输入修复前后输出逐字节一致
- [x] 编译烟测：完整修改版 UtilityPathTests.cs + 修复后 PathHelper + Utility.Path 门面对 Unity nunit.framework.dll 编译 0 错误
- [ ] Unity Editor 导入包无编译报错；Test Runner 执行新增 7 用例（本环境无法启动 Editor，人工项）
- [ ] imagecache / startup 等消费方绝对路径场景落盘位置正确（附带纠正包内 BuildProductHelper.cs:270 传 `projectDir.Parent.FullName` 绝对路径段的同款粘连）

Linear: GFX-724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复路径拼接时分隔符判断错误的问题。
  * 现在会为缺少末尾分隔符的路径段正确添加分隔符，并避免重复添加。

* **Tests**
  * 新增多项路径拼接测试，覆盖相对路径、绝对路径及不同斜杠组合等场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->